### PR TITLE
File name corrected in install script

### DIFF
--- a/tools/install.sh
+++ b/tools/install.sh
@@ -86,7 +86,7 @@ git clone -q https://github.com/fantaosha/LLDB-Eigen-Pretty-Printer.git $INSTALL
 # Add to lldbinit
 #
 trap - Err
-$(cat ~/.lldbinit 2>/dev/null | grep "LLDB-Eigen-Pretty-Printer.py")
+$(cat ~/.lldbinit 2>/dev/null | grep "LLDB_Eigen_Pretty_Printer.py")
 ALREADY_INSTALLED=$?
 trap error_handler Err
 notice "Adding pretty printer to ~/.lldbinit"


### PR DESCRIPTION
Just noticed that the file name that is checked for existance inside the `.lldbinit` file during install was not named correctly. This should fix it.

By the way: Thanks for your great work!