### PR TITLE
Removed unused semicolon

### DIFF
--- a/LLDB_Eigen_Pretty_Printer.py
+++ b/LLDB_Eigen_Pretty_Printer.py
@@ -93,7 +93,7 @@ class Matrix(Printer):
 
             self.options = 0
             if len(template_params) > 3:
-                self.options = int(template_params[3]);
+                self.options = int(template_params[3])
 
             self.rowMajor = (int(self.options) & 0x1)
             self.innerType = template_params[0]


### PR DESCRIPTION
Really small 'fix'. As you don't need semicolons in python (an never used them elsewhere in the file) I would recommend to remove this single one.